### PR TITLE
Fix wcwidth import and match safeWcswidth to its documented behavior

### DIFF
--- a/src/Graphics/Text/Width.hs
+++ b/src/Graphics/Text/Width.hs
@@ -8,7 +8,12 @@ module Graphics.Text.Width ( wcwidth
                            )
     where
 
-foreign import ccall unsafe "vty_mk_wcwidth" wcwidth :: Char -> Int
+import Foreign.C.Types (CInt(..))
+
+foreign import ccall unsafe "vty_mk_wcwidth" c_wcwidth :: Char -> CInt
+
+wcwidth :: Char -> Int
+wcwidth = fromIntegral . c_wcwidth
 
 wcswidth :: String -> Int
 wcswidth = sum . map wcwidth
@@ -22,13 +27,8 @@ wcswidth = sum . map wcwidth
 
 -- | Returns the display width of a character. Assumes all characters with unknown widths are 0 width
 safeWcwidth :: Char -> Int
-safeWcwidth c = case wcwidth c of
-    i   | i < 0 -> 0
-        | otherwise -> i
+safeWcwidth = max 0 . wcwidth
 
 -- | Returns the display width of a string. Assumes all characters with unknown widths are 0 width
 safeWcswidth :: String -> Int
-safeWcswidth str = case wcswidth str of
-    i   | i < 0 -> 0
-        | otherwise -> i
-
+safeWcswidth = sum . map safeWcwidth


### PR DESCRIPTION
Previously vty_mk_wcwidth was being imported with the wrong type causing
the -1 return value to be mapped to the wrong Int value.

Additionally safeWcswidth was using the unsafe character width function
and only ensuring that the final result was non-negative.
