### PR TITLE
Add support for absolute cursor positioning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+5.10
+  - Add aboslute cursor positioning mode AbsoluteCursor to Cursor
+
 5.9.1
   - Vty now only emits UTF8 charset sequences in terminals without a
     preexisting UTF8 declaration to avoid emitting garbage sequences

--- a/src/Graphics/Vty.hs
+++ b/src/Graphics/Vty.hs
@@ -129,43 +129,25 @@ intMkVty input out = do
     lastUpdateRef <- newIORef Nothing
 
     let innerUpdate inPic = do
-            b@(w,h) <- displayBounds out
+            b <- displayBounds out
             let cursor  = picCursor inPic
-                inPic' = case cursor of
-                  AbsoluteCursor x y ->
-                    let x' = max 0 (min (w-1) x)
-                        y' = max 0 (min (h-1) y)
-                    in inPic { picCursor = AbsoluteCursor x' y' }
-                  -- TODO: account for logical width in Cursor case
-                  Cursor x y ->
-                    let
-                       x'      = case x of
-                                   _ | x < 0     -> 0
-                                     | x >= w    -> w - 1
-                                     | otherwise -> x
-                       y'      = case y of
-                                   _ | y < 0     -> 0
-                                     | y >= h    -> h - 1
-                                     | otherwise -> y
-                     in inPic { picCursor = Cursor x' y' }
-                  _ -> inPic
             mlastUpdate <- readIORef lastUpdateRef
             updateData <- case mlastUpdate of
                 Nothing -> do
                     dc <- displayContext out b
-                    outputPicture dc inPic'
+                    outputPicture dc inPic
                     return (b, dc)
                 Just (lastBounds, lastContext) -> do
                     if b /= lastBounds
                         then do
                             dc <- displayContext out b
-                            outputPicture dc inPic'
+                            outputPicture dc inPic
                             return (b, dc)
                         else do
-                            outputPicture lastContext inPic'
+                            outputPicture lastContext inPic
                             return (b, lastContext)
             writeIORef lastUpdateRef $ Just updateData
-            writeIORef lastPicRef $ Just inPic'
+            writeIORef lastPicRef $ Just inPic
 
     let innerRefresh = do
             writeIORef lastUpdateRef Nothing

--- a/src/Graphics/Vty.hs
+++ b/src/Graphics/Vty.hs
@@ -132,6 +132,11 @@ intMkVty input out = do
             b@(w,h) <- displayBounds out
             let cursor  = picCursor inPic
                 inPic' = case cursor of
+                  AbsoluteCursor x y ->
+                    let x' = max 0 (min (w-1) x)
+                        y' = max 0 (min (h-1) y)
+                    in inPic { picCursor = AbsoluteCursor x' y' }
+                  -- TODO: account for logical width in Cursor case
                   Cursor x y ->
                     let
                        x'      = case x of

--- a/src/Graphics/Vty/Config.hs
+++ b/src/Graphics/Vty/Config.hs
@@ -266,7 +266,7 @@ parseModifier :: forall s u (m :: * -> *).
 parseModifier = do
     m <- P.identifier configLexer
     case m of
-        "KMenu" -> return MShift
+        "MShift" -> return MShift
         "MCtrl" -> return MCtrl
         "MMeta" -> return MMeta
         "MAlt" -> return MAlt

--- a/src/Graphics/Vty/Output/Interface.hs
+++ b/src/Graphics/Vty/Output/Interface.hs
@@ -168,7 +168,9 @@ outputPicture dc pic = liftIO $ do
               `mappend`
                 (case picCursor pic of
                     _ | not manipCursor -> mempty
-                    NoCursor             -> mempty
+                    NoCursor            -> mempty
+                    AbsoluteCursor x y ->
+                        writeShowCursor dc `mappend` writeMoveCursor dc x y
                     Cursor x y           ->
                         let m = cursorOutputMap ops $ picCursor pic
                             (ox, oy) = charToOutputPos m (x,y)

--- a/src/Graphics/Vty/Picture.hs
+++ b/src/Graphics/Vty/Picture.hs
@@ -69,13 +69,16 @@ picForLayers is = Picture
 --
 -- todo: The Cursor can be given a (character,row) offset outside of the visible bounds of the
 -- output region. In this case the cursor will not be shown.
-data Cursor = 
+data Cursor =
+      -- | Hide the cursor
       NoCursor
-    | Cursor Int Int
+      -- | Show the cursor at the given logical column accounting for char width and row
+    | Cursor !Int !Int
+      -- | Show the cursor at the given absolute terminal column and row
+    | AbsoluteCursor !Int !Int
 
 instance NFData Cursor where
-    rnf NoCursor = ()
-    rnf (Cursor w h) = w `seq` h `seq` ()
+    rnf c = c `seq` ()
 
 -- | A 'Picture' has a background pattern. The background is either ClearBackground. Which shows the
 -- layer below or is blank if the bottom layer. Or the background pattern is a character and a
@@ -85,11 +88,11 @@ instance NFData Cursor where
 -- \todo The current attribute is always set to the default attributes at the start of updating the
 -- screen to a picture.
 data Background
-    = Background 
+    = Background
     { backgroundChar :: Char
     , backgroundAttr :: Attr
     }
-     -- | A ClearBackground is: 
+     -- | A ClearBackground is:
      --
      -- * the space character if there are remaining non-skip ops
      --

--- a/vty.cabal
+++ b/vty.cabal
@@ -1,5 +1,5 @@
 name:                vty
-version:             5.9.1
+version:             5.10
 license:             BSD3
 license-file:        LICENSE
 author:              AUTHORS


### PR DESCRIPTION
This allows advanced applications to compute their own direct cursor
placement by absolute column without having to invert the logical
cursor computation.

Fixes #94
