### PR TITLE
Emit warning message before crash with missing TERM

### DIFF
--- a/src/Graphics/Vty/Config.hs
+++ b/src/Graphics/Vty/Config.hs
@@ -79,6 +79,7 @@ import Control.Monad (liftM, guard, void)
 
 import qualified Data.ByteString as BS
 import Data.Default
+import Data.Maybe
 import Data.Monoid
 
 import Graphics.Vty.Input.Events
@@ -167,7 +168,7 @@ overrideEnvConfig = do
 
 standardIOConfig :: IO Config
 standardIOConfig = do
-    Just t <- getEnv "TERM"
+    t <- fromMaybe (error "TERM is missing") <$> getEnv "TERM"
     return $ def { vmin = Just 1
                  , mouseMode = Just False
                  , bracketedPasteMode = Just False


### PR DESCRIPTION
Relates to #107.  Instead of directly crashing with a missing TERM, print an error message.
