### PR TITLE
Remove 'emptyImage' overrides for zero-length HorizText

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test/benchmark
 .cabal-sandbox
 cabal.sandbox.config
 test/cabal.sandbox.config
+.stack-work

--- a/src/Graphics/Vty/Image.hs
+++ b/src/Graphics/Vty/Image.hs
@@ -88,17 +88,13 @@ vertCat = foldr vertJoin EmptyImage
 
 -- | A Data.Text.Lazy value
 text :: Attr -> TL.Text -> Image
-text a txt
-    | TL.length txt == 0 = EmptyImage
-    | otherwise          = let displayWidth = safeWcswidth (TL.unpack txt)
-                           in HorizText a txt displayWidth (fromIntegral $! TL.length txt)
+text a txt = let displayWidth = safeWcswidth (TL.unpack txt)
+             in HorizText a txt displayWidth (fromIntegral $! TL.length txt)
 
 -- | A Data.Text value
 text' :: Attr -> T.Text -> Image
-text' a txt
-    | T.length txt == 0 = EmptyImage
-    | otherwise         = let displayWidth = safeWcswidth (T.unpack txt)
-                          in HorizText a (TL.fromStrict txt) displayWidth (T.length txt)
+text' a txt = let displayWidth = safeWcswidth (T.unpack txt)
+              in HorizText a (TL.fromStrict txt) displayWidth (T.length txt)
 
 -- | an image of a single character. This is a standard Haskell 31-bit character assumed to be in
 -- the ISO-10646 encoding.
@@ -117,7 +113,6 @@ char a c =
 -- directly to iso10646String or string.
 -- 
 iso10646String :: Attr -> String -> Image
-iso10646String _ [] = EmptyImage
 iso10646String a str =
     let displayWidth = safeWcswidth str
     in HorizText a (TL.pack str) displayWidth (length str)

--- a/src/Graphics/Vty/Image/Internal.hs
+++ b/src/Graphics/Vty/Image/Internal.hs
@@ -66,14 +66,14 @@ clipText txt leftSkip rightClip =
 --
 -- * an empty image of no size or content.
 data Image = 
-    -- | A horizontal text span is always >= 1 column and has a row height of 1.
+    -- | A horizontal text span has a row height of 1.
       HorizText
       { attr :: Attr
       -- | The text to display. The display width of the text is always outputWidth.
       , displayText :: DisplayText
-      -- | The number of display columns for the text. Always > 0.
+      -- | The number of display columns for the text.
       , outputWidth :: Int
-      -- | the number of characters in the text. Always > 0.
+      -- | the number of characters in the text.
       , charWidth :: Int
       }
     -- | A horizontal join can be constructed between any two images. However a HorizJoin instance is
@@ -82,7 +82,7 @@ data Image =
     | HorizJoin
       { partLeft :: Image 
       , partRight :: Image
-      , outputWidth :: Int -- ^ imageWidth partLeft == imageWidth partRight. Always > 1
+      , outputWidth :: Int -- ^ imageWidth partLeft == imageWidth partRight. Always > 0
       , outputHeight :: Int -- ^ imageHeight partLeft == imageHeight partRight. Always > 0
       }
     -- | A veritical join can be constructed between any two images. However a VertJoin instance is

--- a/src/Graphics/Vty/PictureToSpans.hs
+++ b/src/Graphics/Vty/PictureToSpans.hs
@@ -309,7 +309,7 @@ addMaybeClippedJoin name skip remaining offset i0Dim i0 i1 size = do
     when (state^.remaining <= 0) $ fail $ name ++ " with remaining <= 0"
     case state^.skip of
         s -- TODO: check if clipped in other dim. if not use addUnclipped
-          | s >= size -> fail $ name ++ " on fully clipped"
+          | s > size -> fail $ name ++ " on fully clipped"
           | s == 0    -> if state^.remaining > i0Dim 
                             then do
                                 addMaybeClipped i0


### PR DESCRIPTION
Addresses https://github.com/coreyoconnor/vty/issues/114,

This change causes text-based images of 0 length to still have Attr effects on the terminal even though they don't render characters. This allows user code to not need to check for zero length text and make special cases it, it also means that adding attributes to existing text blocks when constructing them into Images is more flexible.

Upon testing in my own app I'm getting this error "horiz_join on fully clipped" from here: https://github.com/coreyoconnor/vty/blob/master/src/Graphics/Vty/PictureToSpans.hs#L312, 

Deleting the line that checks for that error causes it to run just fine without any other effects so far as I can observe, not really sure what it's meant to check. Any pointers on where to go with this would be appreciated. 