### PR TITLE
Rogue: Remove unused language extension, TemplateHaskell

### DIFF
--- a/test/Rogue.hs
+++ b/test/Rogue.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
 module Main where
 
 import Graphics.Vty


### PR DESCRIPTION
This is a super minor thing, but when I was reading the code I noticed that it doesn't currently use the `TemplateHaskell` extension so I figured might as well remove it.