### PR TITLE
Handle mouse wheel events

### DIFF
--- a/src/Graphics/Vty/Input/Events.hs
+++ b/src/Graphics/Vty/Input/Events.hs
@@ -43,7 +43,6 @@ data Event
     -- row. Some terminals report only that a button was released
     -- without specifying which one; in that case, Nothing is provided.
     -- Otherwise Just the button released is included in the event.
-    -- Mouse wheel release events are not reported.
     | EvResize Int Int
     -- ^ If read from 'eventChannel' this is the size at the time of the
     -- signal. If read from 'nextEvent' this is the size at the time the

--- a/src/Graphics/Vty/Input/Events.hs
+++ b/src/Graphics/Vty/Input/Events.hs
@@ -28,7 +28,7 @@ data Modifier = MShift | MCtrl | MMeta | MAlt
     deriving (Eq,Show,Read,Ord,Generic)
 
 -- | Mouse buttons.
-data Button = BLeft | BMiddle | BRight
+data Button = BLeft | BMiddle | BRight | BWheelUp | BWheelDown
     deriving (Eq,Show,Read,Ord,Generic)
 
 -- | Events.
@@ -43,6 +43,7 @@ data Event
     -- row. Some terminals report only that a button was released
     -- without specifying which one; in that case, Nothing is provided.
     -- Otherwise Just the button released is included in the event.
+    -- Mouse wheel release events are not reported.
     | EvResize Int Int
     -- ^ If read from 'eventChannel' this is the size at the time of the
     -- signal. If read from 'nextEvent' this is the size at the time the

--- a/src/Graphics/Vty/Input/Events.hs
+++ b/src/Graphics/Vty/Input/Events.hs
@@ -28,7 +28,7 @@ data Modifier = MShift | MCtrl | MMeta | MAlt
     deriving (Eq,Show,Read,Ord,Generic)
 
 -- | Mouse buttons.
-data Button = BLeft | BMiddle | BRight | BWheelUp | BWheelDown
+data Button = BLeft | BMiddle | BRight | BScrollUp | BScrollDown
     deriving (Eq,Show,Read,Ord,Generic)
 
 -- | Events.

--- a/src/Graphics/Vty/Input/Mouse.hs
+++ b/src/Graphics/Vty/Input/Mouse.hs
@@ -78,11 +78,11 @@ middleButton = 1
 rightButton :: Int
 rightButton = 2
 
-wheelUp :: Int
-wheelUp = 64
+scrollUp :: Int
+scrollUp = 64
 
-wheelDown :: Int
-wheelDown = 65
+scrollDown :: Int
+scrollDown = 65
 
 hasBitSet :: Int -> Int -> Bool
 hasBitSet val bit = val .&. bit > 0
@@ -106,8 +106,8 @@ getSGRButton mods =
     let buttonMap = [ (leftButton,   BLeft)
                     , (middleButton, BMiddle)
                     , (rightButton,  BRight)
-                    , (wheelUp,      BWheelUp)
-                    , (wheelDown,    BWheelDown)
+                    , (scrollUp,     BScrollUp)
+                    , (scrollDown,   BScrollDown)
                     ]
     in case lookup (mods .&. buttonMask) buttonMap of
         Nothing -> failParse

--- a/src/Graphics/Vty/Input/Mouse.hs
+++ b/src/Graphics/Vty/Input/Mouse.hs
@@ -67,7 +67,7 @@ ctrlBit = 16
 
 -- These bits indicate the buttons involved:
 buttonMask :: Int
-buttonMask = 3
+buttonMask = 67
 
 leftButton :: Int
 leftButton = 0
@@ -77,6 +77,12 @@ middleButton = 1
 
 rightButton :: Int
 rightButton = 2
+
+wheelUp :: Int
+wheelUp = 64
+
+wheelDown :: Int
+wheelDown = 65
 
 hasBitSet :: Int -> Int -> Bool
 hasBitSet val bit = val .&. bit > 0
@@ -100,6 +106,8 @@ getSGRButton mods =
     let buttonMap = [ (leftButton,   BLeft)
                     , (middleButton, BMiddle)
                     , (rightButton,  BRight)
+                    , (wheelUp,      BWheelUp)
+                    , (wheelDown,    BWheelDown)
                     ]
     in case lookup (mods .&. buttonMask) buttonMap of
         Nothing -> failParse


### PR DESCRIPTION
Scroll up/down events were interpreted as BLeft/BMiddle down events.
Introduced BWheelUp/BWheelDown events to handle these, tested with the vty-mode-demo.

I'm unsure about the names; maybe BScrollUp/Down sound better?

Reference: http://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Wheel-mice