### PR TITLE
Fix haddock markup for Monoid instance of Image

### DIFF
--- a/src/Graphics/Vty/Image/Internal.hs
+++ b/src/Graphics/Vty/Image/Internal.hs
@@ -232,7 +232,7 @@ imageHeight CropBottom { outputHeight = h } = h
 imageHeight CropTop { outputHeight = h } = h
 imageHeight EmptyImage = 0
 
--- | Append in the Monoid instance is equivalent to <->.
+-- | Append in the Monoid instance is equivalent to '<->'.
 instance Monoid Image where
     mempty = EmptyImage
     mappend = vertJoin


### PR DESCRIPTION
It doesn't link because '<->' is not imported, but it at least shows up correctly in the haddocks this way.