### PR TITLE
Add Semigroup instances

### DIFF
--- a/src/Data/Terminfo/Parse.hs
+++ b/src/Data/Terminfo/Parse.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_HADDOCK hide #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -13,6 +14,9 @@ where
 import Control.Monad ( liftM )
 import Control.DeepSeq
 
+#if !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup (Semigroup(..))
+#endif
 import Data.Word
 import qualified Data.Vector.Unboxed as Vector
 
@@ -329,11 +333,16 @@ data BuildResults = BuildResults
     , outParamOps :: !ParamOps
     }
 
-instance Monoid BuildResults where
-    mempty = BuildResults 0 [] []
-    v0 `mappend` v1
+instance Semigroup BuildResults where
+    v0 <> v1
         = BuildResults
         { outParamCount = (outParamCount v0) `max` (outParamCount v1)
-        , outCapOps = (outCapOps v0) `mappend` (outCapOps v1)
-        , outParamOps = (outParamOps v0) `mappend` (outParamOps v1)
+        , outCapOps = (outCapOps v0) <> (outCapOps v1)
+        , outParamOps = (outParamOps v0) <> (outParamOps v1)
         }
+
+instance Monoid BuildResults where
+    mempty = BuildResults 0 [] []
+#if !(MIN_VERSION_base(4,11,0))
+    mappend = (<>)
+#endif

--- a/src/Graphics/Vty.hs
+++ b/src/Graphics/Vty.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- | Vty provides interfaces for both terminal input and terminal
 -- output.
 --
@@ -50,7 +52,9 @@ import Graphics.Vty.Attributes
 import Control.Concurrent.STM
 
 import Data.IORef
-import Data.Monoid
+#if !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup ((<>))
+#endif
 
 -- | A Vty value represents a handle to the Vty library that the
 -- application must create in order to use Vty.

--- a/src/Graphics/Vty/Image/Internal.hs
+++ b/src/Graphics/Vty/Image/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# OPTIONS_HADDOCK hide #-}
@@ -11,6 +12,9 @@ import GHC.Generics
 
 import Control.DeepSeq
 
+#if !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup (Semigroup(..))
+#endif
 import qualified Data.Text.Lazy as TL
 
 -- | A display text is a Data.Text.Lazy
@@ -232,10 +236,16 @@ imageHeight CropBottom { outputHeight = h } = h
 imageHeight CropTop { outputHeight = h } = h
 imageHeight EmptyImage = 0
 
--- | Append in the Monoid instance is equivalent to '<->'.
+-- | Append in the 'Semigroup' instance is equivalent to '<->'.
+instance Semigroup Image where
+    (<>) = vertJoin
+
+-- | Append in the 'Monoid' instance is equivalent to '<->'.
 instance Monoid Image where
     mempty = EmptyImage
-    mappend = vertJoin
+#if !(MIN_VERSION_base(4,11,0))
+    mappend = (<>)
+#endif
 
 -- | combines two images side by side
 --

--- a/vty.cabal
+++ b/vty.cabal
@@ -61,6 +61,9 @@ library
                        utf8-string >= 0.3 && < 1.1,
                        vector >= 0.7
 
+  if !impl(ghc >= 8.0)
+    build-depends:     semigroups >= 0.16
+
   exposed-modules:     Graphics.Vty
                        Graphics.Vty.Attributes
                        Graphics.Vty.Config


### PR DESCRIPTION
This is needed to fix the build on GHC 8.4, where `Semigroup` has become a superclass of `Monoid`.