### PR TITLE
Fix SGR command after italics change

### DIFF
--- a/src/Graphics/Vty/Attributes.hs
+++ b/src/Graphics/Vty/Attributes.hs
@@ -175,7 +175,7 @@ instance Eq v => Monoid ( MaybeDefault v ) where
 -- if the style attribute should not be applied.
 type Style = Word8
 
--- | The 6 possible style attributes:
+-- | The 7 possible style attributes:
 --
 --      * standout
 --
@@ -196,7 +196,7 @@ type Style = Word8
 standout, underline, reverseVideo, blink, dim, bold, italic :: Style
 standout        = 0x01
 underline       = 0x02
-reverseVideo   = 0x04
+reverseVideo    = 0x04
 blink           = 0x08
 dim             = 0x10
 bold            = 0x20


### PR DESCRIPTION
SGR doesn't control italics. If we're updating the terminal style
using SGR and italics are needed the enter sequence will have to
be added after the SGR command.

Fixes #155 