### PR TITLE
Changed System.Posix.Env (specifically 'getEnv') to System.Environment

### DIFF
--- a/src/Graphics/Vty/Config.hs
+++ b/src/Graphics/Vty/Config.hs
@@ -87,7 +87,7 @@ import Graphics.Vty.Input.Events
 import GHC.Generics
 
 import System.Directory (getAppUserDataDirectory)
-import System.Posix.Env (getEnv)
+import System.Environment (lookupEnv)
 import System.Posix.IO (stdInput, stdOutput)
 import System.Posix.Types (Fd(..))
 
@@ -176,20 +176,20 @@ instance Monoid Config where
 userConfig :: IO Config
 userConfig = do
     configFile <- (mappend <$> getAppUserDataDirectory "vty" <*> pure "/config") >>= parseConfigFile
-    overrideConfig <- maybe (return defaultConfig) parseConfigFile =<< getEnv "VTY_CONFIG_FILE"
+    overrideConfig <- maybe (return defaultConfig) parseConfigFile =<< lookupEnv "VTY_CONFIG_FILE"
     let base = configFile <> overrideConfig
     mappend base <$> overrideEnvConfig
 
 overrideEnvConfig :: IO Config
 overrideEnvConfig = do
-    d <- getEnv "VTY_DEBUG_LOG"
+    d <- lookupEnv "VTY_DEBUG_LOG"
     return $ defaultConfig { debugLog = d }
 
 -- | Configures VTY using defaults suitable for terminals. This function
 -- can raise 'VtyConfigurationError'.
 standardIOConfig :: IO Config
 standardIOConfig = do
-    mb <- getEnv "TERM"
+    mb <- lookupEnv "TERM"
     case mb of
       Nothing -> throwIO VtyMissingTermEnvVar
       Just t ->

--- a/test/VerifyOutput.hs
+++ b/test/VerifyOutput.hs
@@ -13,7 +13,6 @@ import Verify.Graphics.Vty.Output
 import Control.Monad
 
 import qualified System.Console.Terminfo as Terminfo
--- import System.Posix.Env
 import System.Posix.IO
 
 tests :: IO [Test]

--- a/test/VerifyOutput.hs
+++ b/test/VerifyOutput.hs
@@ -13,7 +13,7 @@ import Verify.Graphics.Vty.Output
 import Control.Monad
 
 import qualified System.Console.Terminfo as Terminfo
-import System.Posix.Env
+-- import System.Posix.Env
 import System.Posix.IO
 
 tests :: IO [Test]


### PR DESCRIPTION
I'm currently trying to add windows support. To make this easier POSIX specific functions have to be switched out with more general versions. This PR switches `getEnv` from `System.Posix.Env` to `lookupEnv` from `System.Environment`. This should be compatible with GHC 7.10.1.