### PR TITLE
Add missing MonadFail constraints

### DIFF
--- a/src/Graphics/Vty/Output.hs
+++ b/src/Graphics/Vty/Output.hs
@@ -38,6 +38,7 @@ import Graphics.Vty.Output.TerminfoBased as TerminfoBased
 
 import Blaze.ByteString.Builder (writeToByteString)
 
+import Control.Monad.Fail (MonadFail)
 import Control.Monad.Trans
 
 import Data.List (isPrefixOf)
@@ -84,7 +85,7 @@ outputForConfig config = (<> config) <$> standardIOConfig >>= outputForConfig
 -- Currently, the only way to set the cursor position to a given
 -- character coordinate is to specify the coordinate in the Picture
 -- instance provided to 'outputPicture' or 'refresh'.
-setCursorPos :: MonadIO m => Output -> Int -> Int -> m ()
+setCursorPos :: (MonadIO m, MonadFail m) => Output -> Int -> Int -> m ()
 setCursorPos t x y = do
     bounds <- displayBounds t
     when (x >= 0 && x < regionWidth bounds && y >= 0 && y < regionHeight bounds) $ do
@@ -92,14 +93,14 @@ setCursorPos t x y = do
         liftIO $ outputByteBuffer t $ writeToByteString $ writeMoveCursor dc x y
 
 -- | Hides the cursor.
-hideCursor :: MonadIO m => Output -> m ()
+hideCursor :: (MonadIO m, MonadFail m) => Output -> m ()
 hideCursor t = do
     bounds <- displayBounds t
     dc <- displayContext t bounds
     liftIO $ outputByteBuffer t $ writeToByteString $ writeHideCursor dc
 
 -- | Shows the cursor.
-showCursor :: MonadIO m => Output -> m ()
+showCursor :: (MonadIO m, MonadFail m) => Output -> m ()
 showCursor t = do
     bounds <- displayBounds t
     dc <- displayContext t bounds

--- a/src/Graphics/Vty/Output/Interface.hs
+++ b/src/Graphics/Vty/Output/Interface.hs
@@ -29,6 +29,7 @@ import Graphics.Vty.DisplayAttributes
 import Blaze.ByteString.Builder (Write, writeToByteString)
 import Blaze.ByteString.Builder.ByteString (writeByteString)
 
+import Control.Monad.Fail (MonadFail)
 import Control.Monad.Trans
 
 import qualified Data.ByteString as BS
@@ -76,7 +77,7 @@ data Output = Output
       -- previous state then set the display state to the initial state.
     , releaseDisplay :: forall m. MonadIO m => m ()
       -- | Returns the current display bounds.
-    , displayBounds :: forall m. MonadIO m => m DisplayRegion
+    , displayBounds :: forall m. (MonadIO m, MonadFail m) => m DisplayRegion
       -- | Output the bytestring to the terminal device.
     , outputByteBuffer :: BS.ByteString -> IO ()
       -- | Specifies the maximum number of colors supported by the

--- a/src/Graphics/Vty/Output/TerminfoBased.hs
+++ b/src/Graphics/Vty/Output/TerminfoBased.hs
@@ -25,6 +25,7 @@ import Graphics.Vty.Output.Interface
 
 import Blaze.ByteString.Builder (Write, writeToByteString, writeStorable)
 
+import Control.Monad.Fail (MonadFail)
 import Control.Monad.Trans
 
 import Data.Bits ((.&.))
@@ -203,25 +204,25 @@ reserveTerminal termName outFd = liftIO $ do
         maybeSendCap s = when (isJust $ s terminfoCaps) . sendCap (fromJust . s)
     return t
 
-requireCap :: (Applicative m, MonadIO m) => Terminfo.Terminal -> String -> m CapExpression
+requireCap :: (Applicative m, MonadIO m, MonadFail m) => Terminfo.Terminal -> String -> m CapExpression
 requireCap ti capName
     = case Terminfo.getCapability ti (Terminfo.tiGetStr capName) of
         Nothing     -> fail $ "Terminal does not define required capability \"" ++ capName ++ "\""
         Just capStr -> parseCap capStr
 
-probeCap :: (Applicative m, MonadIO m) => Terminfo.Terminal -> String -> m (Maybe CapExpression)
+probeCap :: (Applicative m, MonadIO m, MonadFail m) => Terminfo.Terminal -> String -> m (Maybe CapExpression)
 probeCap ti capName
     = case Terminfo.getCapability ti (Terminfo.tiGetStr capName) of
         Nothing     -> return Nothing
         Just capStr -> Just <$> parseCap capStr
 
-parseCap :: (Applicative m, MonadIO m) => String -> m CapExpression
+parseCap :: (Applicative m, MonadIO m, MonadFail m) => String -> m CapExpression
 parseCap capStr = do
     case parseCapExpression capStr of
         Left e -> fail $ show e
         Right cap -> return cap
 
-currentDisplayAttrCaps :: ( Applicative m, MonadIO m )
+currentDisplayAttrCaps :: ( Applicative m, MonadIO m, MonadFail m )
                        => Terminfo.Terminal
                        -> m DisplayAttrCaps
 currentDisplayAttrCaps ti

--- a/vty.cabal
+++ b/vty.cabal
@@ -30,7 +30,7 @@ extra-doc-files:     README.md,
                      AUTHORS,
                      CHANGELOG.md,
                      LICENSE
-tested-with:         GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.3
+tested-with:         GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.3, GHC==8.6.5
 
 source-repository head
   type: git
@@ -62,7 +62,8 @@ library
                        vector >= 0.7
 
   if !impl(ghc >= 8.0)
-    build-depends:     semigroups >= 0.16
+    build-depends:     semigroups >= 0.16,
+                       fail
 
   exposed-modules:     Graphics.Vty
                        Graphics.Vty.Attributes


### PR DESCRIPTION
Beginning with GHC 8.8 and base 4.13, `fail` is no longer part of the `Monad` class. Hence this patch, which does the following:

* Add the missing `MonadFail` constraints.

* Import `Control.Monad.Fail` where necessary to bring `MonadFail` into scope for bases 4.9 through 4.12. On base >= 4.13 (so GHC 8.8 and up), this causes a redundant import warning, but I didn't want to introduce CPP to handle this; besides, on 8.8 there are already a number of redundant import warnings, so maybe a future patch could tackle those all at once.

* Add a dependency on the `fail` package for GHC < 8.0 to provide `MonadFail` for older GHCs. This is in line with the existing conditional dependency on `semigroup`.

I've built this patch with GHCs 7.10.3, 8.6.5 and 8.8.1 and it works fine. The testsuite passes for 8.6.5, so I also indicated that in the cabal file's `tested-with` list. It would most certainly also pass for GHC 8.8.1, but alas it doesn't run due to some dependency issues (`regex-base`, somewhere in the dependency chain, seems to not be ready for base 4.13 yet either), but I am confident vty would pass all tests on 8.8.1, since the changes are purely non-functional.
