### PR TITLE
Makes vty compile on systems that build a split ncurses & tinfo .so

### DIFF
--- a/vty.cabal
+++ b/vty.cabal
@@ -36,6 +36,10 @@ source-repository head
   type: git
   location: https://github.com/jtdaugherty/vty.git
 
+flag no-pkgconfig
+  description:         Don't use pkg-config to check for library dependencies
+  default:             False
+
 library
   default-language:    Haskell2010
   build-depends:       base >= 4.8 && < 5,
@@ -116,6 +120,9 @@ library
                        ForeignFunctionInterface
 
   ghc-options:         -O2 -funbox-strict-fields -Wall -fspec-constr -fspec-constr-count=10
+
+  if !flag(no-pkgconfig)
+    pkgconfig-depends:   ncurses
 
   ghc-prof-options:    -O2 -funbox-strict-fields -caf-all -Wall -fspec-constr -fspec-constr-count=10
 


### PR DESCRIPTION
Some Linux distributions (such as Gentoo) build ncurses with a split-out
tinfo library. On those platforms vty applications will fail to build
because symbols like 'set_curterm' are only defined when using
'-ltinfo -lcurses' instead of just '-lcurses'.
pkg-config will always provide the correct linking options on platforms
that have pkg-config installed. All other systems can use the flag
'no-pkgconfig' to cabal configure to prevent cabal calling pkg-config.