### PR TITLE
Simplify definition of MaybeDefault

### DIFF
--- a/src/Graphics/Vty/Attributes.hs
+++ b/src/Graphics/Vty/Attributes.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveAnyClass #-}
 
@@ -146,19 +143,13 @@ data FixedAttr = FixedAttr
 -- | The style and color attributes can either be the terminal defaults.
 -- Or be equivalent to the previously applied style. Or be a specific
 -- value.
-data MaybeDefault v where
-    Default :: MaybeDefault v
-    KeepCurrent :: MaybeDefault v
-    SetTo :: forall v . ( Eq v, Show v, Read v ) => !v -> MaybeDefault v
+data MaybeDefault v = Default | KeepCurrent | SetTo !v
+  deriving (Eq, Read, Show)
 
 instance (NFData v) => NFData (MaybeDefault v) where
     rnf Default = ()
     rnf KeepCurrent = ()
     rnf (SetTo v) = rnf v
-
-deriving instance Eq v => Eq (MaybeDefault v)
-deriving instance Eq v => Show (MaybeDefault v)
-deriving instance (Eq v, Show v, Read v) => Read (MaybeDefault v)
 
 instance Eq v => Semigroup (MaybeDefault v) where
     Default     <> Default     = Default


### PR DESCRIPTION
The previous version of MaybeDefault stores pointers to the Eq, Show, and Read instances of the defaulted value.

MaybeDefault is used with Style, Color, and Text. All of these types already have all of the necessary instances, and we never work with MaybeDefault generically. Defering the Show, Eq, and Read instances down to the SetTo case isn't helping us to work with types that don't have these instances.

My particular reason for wanting this change is that I want to be able to store Attr in a *compact region* as implemented in `ghc-compact`. This GHC feature doesn't work with functions, and the encoding of putting the constraints in the context of `SetTo` is that you're putting functions as parameters to that constructor. Making this code less clever makes the SetTo constructor smaller (by at least 3 pointers) and allows us to remove functions from the image representation types.