### PR TITLE
Fix upper bound for `random`

### DIFF
--- a/vty.cabal
+++ b/vty.cabal
@@ -543,7 +543,7 @@ test-suite verify-color-mapping
   build-depends:       vty,
                        Cabal >= 1.20,
                        QuickCheck >= 2.7,
-                       random >= 1.0 && < 1.2,
+                       random >= 1.0 && < 1.3,
                        base >= 4.8 && < 5,
                        bytestring,
                        containers,


### PR DESCRIPTION
It was missing in https://github.com/jtdaugherty/vty/commit/05b65fc5bc9e67575de52018f7365c6dbcd13c38#diff-bbe7cbd3346ad764f4c6f56880116550ee4f4a768d2a578ede1c0ce22b36fb4f