### PR TITLE
A simpler version of the Semigroup instance for MaybeDefault

### DIFF
--- a/src/Graphics/Vty/Attributes.hs
+++ b/src/Graphics/Vty/Attributes.hs
@@ -152,10 +152,9 @@ instance (NFData v) => NFData (MaybeDefault v) where
     rnf (SetTo v) = rnf v
 
 instance Eq v => Semigroup (MaybeDefault v) where
-    _           <> v@(SetTo _) = v
-    x           <> KeepCurrent = x
-    Default     <> _           = Default
-    _           <> Default     = Default
+    _        <> v@(SetTo _) = v
+    x        <> KeepCurrent = x
+    _        <> Default     = Default
 
 instance Eq v => Monoid ( MaybeDefault v ) where
     mempty = KeepCurrent

--- a/src/Graphics/Vty/Attributes.hs
+++ b/src/Graphics/Vty/Attributes.hs
@@ -155,7 +155,7 @@ instance Eq v => Semigroup (MaybeDefault v) where
     _           <> v@(SetTo _) = v
     x           <> KeepCurrent = x
     Default     <> _           = Default
-    _           <> Default    = Default
+    _           <> Default     = Default
 
 instance Eq v => Monoid ( MaybeDefault v ) where
     mempty = KeepCurrent

--- a/src/Graphics/Vty/Attributes.hs
+++ b/src/Graphics/Vty/Attributes.hs
@@ -154,7 +154,7 @@ instance (NFData v) => NFData (MaybeDefault v) where
 instance Eq v => Semigroup (MaybeDefault v) where
     _        <> v@(SetTo _) = v
     x        <> KeepCurrent = x
-    _        <> Default     = Default
+    _        <> ~Default    = Default
 
 instance Eq v => Monoid ( MaybeDefault v ) where
     mempty = KeepCurrent

--- a/src/Graphics/Vty/Attributes.hs
+++ b/src/Graphics/Vty/Attributes.hs
@@ -152,15 +152,10 @@ instance (NFData v) => NFData (MaybeDefault v) where
     rnf (SetTo v) = rnf v
 
 instance Eq v => Semigroup (MaybeDefault v) where
-    Default     <> Default     = Default
-    Default     <> KeepCurrent = Default
-    Default     <> SetTo v     = SetTo v
-    KeepCurrent <> Default     = Default
-    KeepCurrent <> KeepCurrent = KeepCurrent
-    KeepCurrent <> SetTo v     = SetTo v
-    SetTo _v    <> Default     = Default
-    SetTo v     <> KeepCurrent = SetTo v
-    SetTo _     <> SetTo v     = SetTo v
+    _           <> v@(SetTo _) = v
+    x           <> KeepCurrent = x
+    Default     <> _           = Default
+    _           <> Default    = Default
 
 instance Eq v => Monoid ( MaybeDefault v ) where
     mempty = KeepCurrent

--- a/src/Graphics/Vty/Attributes.hs
+++ b/src/Graphics/Vty/Attributes.hs
@@ -154,7 +154,7 @@ instance (NFData v) => NFData (MaybeDefault v) where
 instance Eq v => Semigroup (MaybeDefault v) where
     _        <> v@(SetTo _) = v
     x        <> KeepCurrent = x
-    _        <> ~Default    = Default
+    _        <> Default     = Default
 
 instance Eq v => Monoid ( MaybeDefault v ) where
     mempty = KeepCurrent

--- a/test/VerifyAttributes.hs
+++ b/test/VerifyAttributes.hs
@@ -2,6 +2,8 @@ module VerifyAttributes where
 
 import Verify
 
+import Data.Semigroup((<>))
+
 import Graphics.Vty.Attributes(MaybeDefault(Default, KeepCurrent, SetTo))
 
 instance Arbitrary a => Arbitrary (MaybeDefault a) where

--- a/test/VerifyAttributes.hs
+++ b/test/VerifyAttributes.hs
@@ -1,0 +1,28 @@
+module VerifyAttributes where
+
+import Verify
+
+import Graphics.Vty.Attributes(MaybeDefault(Default, KeepCurrent, SetTo))
+
+instance Arbitrary a => Arbitrary (MaybeDefault a) where
+  arbitrary = oneof [pure Default, pure KeepCurrent, SetTo <$> arbitrary]
+
+oldSem :: MaybeDefault a -> MaybeDefault a -> MaybeDefault a
+oldSem Default Default = Default
+oldSem Default KeepCurrent = Default
+oldSem Default (SetTo v) = SetTo v
+oldSem KeepCurrent Default = Default
+oldSem KeepCurrent KeepCurrent = KeepCurrent
+oldSem KeepCurrent (SetTo v) = SetTo v
+oldSem (SetTo _v) Default = Default
+oldSem (SetTo v) KeepCurrent = SetTo v
+oldSem (SetTo _) (SetTo v) = SetTo v
+
+sameSemigroupValue :: MaybeDefault Int -> MaybeDefault Int -> Bool
+sameSemigroupValue xa xb = xa <> xb == oldSem xa xb
+
+tests :: IO [Test]
+tests = return
+  [ verify "check that the new Semigroup of MaybeDefault is equivalent to the old one" sameSemigroupValue
+  ]
+

--- a/vty.cabal
+++ b/vty.cabal
@@ -554,6 +554,32 @@ test-suite verify-color-mapping
                        utf8-string >= 0.3 && < 1.1,
                        vector >= 0.7
 
+test-suite verify-semigroup-maybedefault
+  default-language:    Haskell2010
+  default-extensions:  ScopedTypeVariables
+
+  type:                detailed-0.9
+
+  hs-source-dirs:      test
+
+  test-module:         VerifyAttributes
+
+  other-modules:       Verify
+
+  build-depends:       vty,
+                       Cabal >= 1.20,
+                       QuickCheck >= 2.7,
+                       random >= 1.0 && < 1.3,
+                       base >= 4.8 && < 5,
+                       bytestring,
+                       containers,
+                       deepseq >= 1.1 && < 1.5,
+                       mtl >= 1.1.1.0 && < 2.3,
+                       text >= 0.11.3,
+                       unix,
+                       utf8-string >= 0.3 && < 1.1,
+                       vector >= 0.7
+
 
 test-suite verify-utf8-width
   default-language:    Haskell2010


### PR DESCRIPTION
The implementation of the `Semigroup` has less clauses, but I think it is also more descriptive since the code "explains" how the semigroup works whereas in the original version it exhaustively enumerated over the items, but without explaining the rules of the semigroup.

Likely the implementation is also slightly more memory efficient, since we return the `SetTo _` parameter, not constructing a new equivalent one. The implementation is also more lazy, since we never evaluate the first parameter here. If the second item is thus `Default` or `SetTo _` we will never evaluate the first parameter.

A test is created to check if the implementation is equivalent to the old `Semigroup` instance.