### PR TITLE
Handle `Ctrl-h` (backspace) in alacritty

### DIFF
--- a/src/Graphics/Vty/Config.hs
+++ b/src/Graphics/Vty/Config.hs
@@ -54,7 +54,7 @@
 -- If a debug log is requested then vty will output the current input
 -- table to the log in the above format. A workflow for using this is
 -- to set @VTY_DEBUG_LOG@. Run the application. Check the debug log for
--- incorrect mappings. Add corrected mappings to @$HOME/.vty/config@.
+-- incorrect mappings. Add corrected mappings to @$HOME\/.vty\/config@.
 --
 -- = Unicode Character Width Maps
 --

--- a/src/Graphics/Vty/Input/Terminfo.hs
+++ b/src/Graphics/Vty/Input/Terminfo.hs
@@ -91,7 +91,7 @@ specialSupportKeys =
     -- special support for ESC
     , ("\ESC",EvKey KEsc []), ("\ESC\ESC",EvKey KEsc [MMeta])
     -- Special support for backspace
-    , ("\DEL",EvKey KBS []), ("\ESC\DEL",EvKey KBS [MMeta])
+    , ("\DEL",EvKey KBS []), ("\ESC\DEL",EvKey KBS [MMeta]), ("\b",EvKey KBS [])
     -- Special support for Enter
     , ("\ESC\^J",EvKey KEnter [MMeta]), ("\^J",EvKey KEnter [])
     -- explicit support for tab


### PR DESCRIPTION
Alacritty sends `\b` on Ctrl-h which is not handled by vty. Adding `map _ "\b" KBS []` to .vty/config solves it.

It seems reasonable to me to fix it at this level, without forcing alacritty users to create a config file manually. However I'm not sure whether it could be safely extrapolated to other terminals. Also tests seem to pass but I'm a bit uneasy with the lack of test case for this specific combination (cannot find tests for others though).

Found it while investigating https://github.com/smallhadroncollider/taskell/issues/86 (other keybindings discussed at that ticket are taskell-specific issues).