### PR TITLE
perf: Mark event data types as strict; unpack some fields.

### DIFF
--- a/src/Graphics/Vty/Input/Classify/Types.hs
+++ b/src/Graphics/Vty/Input/Classify/Types.hs
@@ -1,5 +1,6 @@
 -- | This module exports the input classification type to avoid import
 -- cycles between other modules that need this.
+{-# StrictData #-}
 module Graphics.Vty.Input.Classify.Types
   ( KClass(..)
   )

--- a/src/Graphics/Vty/Input/Events.hs
+++ b/src/Graphics/Vty/Input/Events.hs
@@ -1,4 +1,5 @@
 {-# Language DeriveGeneric #-}
+{-# Language StrictData #-}
 module Graphics.Vty.Input.Events where
 
 import Control.DeepSeq
@@ -15,10 +16,10 @@ import GHC.Generics
 --
 -- * Actually, support for most of these but KEsc, KChar, KBS, and
 -- KEnter vary by terminal and keyboard.
-data Key = KEsc  | KChar Char | KBS | KEnter
+data Key = KEsc  | KChar {-# UNPACK #-} Char | KBS | KEnter
          | KLeft | KRight | KUp | KDown
          | KUpLeft | KUpRight | KDownLeft | KDownRight | KCenter
-         | KFun Int | KBackTab | KPrtScr | KPause | KIns
+         | KFun {-# UNPACK #-} Int | KBackTab | KPrtScr | KPause | KIns
          | KHome | KPageUp | KDel | KEnd | KPageDown | KBegin | KMenu
     deriving (Eq,Show,Read,Ord,Generic)
 


### PR DESCRIPTION
Integral types like Char and Int benefit a lot from UNPACK. For these,
there is also very little reason to use lazy fields, especially in this
codebase where most computations don't need laziness.