### PR TITLE
cleanup: Make ScopedTypeVariables explicit in files that use it.

### DIFF
--- a/src/Data/Terminfo/Parse.hs
+++ b/src/Data/Terminfo/Parse.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
-{-# OPTIONS_HADDOCK hide #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -funbox-strict-fields -O #-}
+{-# OPTIONS_HADDOCK hide #-}
 
 module Data.Terminfo.Parse
   ( module Data.Terminfo.Parse

--- a/src/Graphics/Vty.hs
+++ b/src/Graphics/Vty.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Vty provides interfaces for both terminal input and terminal
 -- output.

--- a/src/Graphics/Vty/Input/Loop.hs
+++ b/src/Graphics/Vty/Input/Loop.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# OPTIONS_HADDOCK hide #-}
-{-# LANGUAGE NoMonomorphismRestriction #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK hide #-}
 -- | The input layer used to be a single function that correctly
 -- accounted for the non-threaded runtime by emulating the terminal
 -- VMIN adn VTIME handling. This has been removed and replace with a

--- a/src/Graphics/Vty/Output/Interface.hs
+++ b/src/Graphics/Vty/Output/Interface.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 -- | This module provides an abstract interface for performing terminal
 -- output. The only user-facing part of this API is 'Output'.
 module Graphics.Vty.Output.Interface

--- a/test/VerifyEmptyImageProps.hs
+++ b/test/VerifyEmptyImageProps.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 module VerifyEmptyImageProps where
 
 import Verify

--- a/test/VerifyEvalTerminfoCaps.hs
+++ b/test/VerifyEvalTerminfoCaps.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module VerifyEvalTerminfoCaps where
 
 import Blaze.ByteString.Builder.Internal.Write (runWrite, getBound)

--- a/test/VerifyImageOps.hs
+++ b/test/VerifyImageOps.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 module VerifyImageOps where
 
 import Graphics.Vty.Attributes

--- a/test/VerifyOutput.hs
+++ b/test/VerifyOutput.hs
@@ -1,6 +1,7 @@
 -- We setup the environment to envoke certain terminals of interest.
 -- This assumes appropriate definitions exist in the current environment
 -- for the terminals of interest.
+{-# LANGUAGE ScopedTypeVariables #-}
 module VerifyOutput where
 
 import Verify

--- a/test/VerifyParseTerminfoCaps.hs
+++ b/test/VerifyParseTerminfoCaps.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module VerifyParseTerminfoCaps where
 
 import Prelude hiding ( catch )

--- a/test/VerifyUsingMockInput.hs
+++ b/test/VerifyUsingMockInput.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 -- Generate some input bytes and delays between blocks of input bytes.
 -- Verify the events produced are as expected.
 module Main where

--- a/vty.cabal
+++ b/vty.cabal
@@ -117,8 +117,6 @@ library
 
   hs-source-dirs:      src
 
-  default-extensions:  ScopedTypeVariables
-
   ghc-options:         -O2 -funbox-strict-fields -Wall -fspec-constr -fspec-constr-count=10
 
   ghc-prof-options:    -O2 -funbox-strict-fields -caf-all -Wall -fspec-constr -fspec-constr-count=10
@@ -143,7 +141,6 @@ executable vty-mode-demo
   hs-source-dirs:      demos
 
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
   ghc-options:         -threaded
 
   build-depends:       vty,
@@ -158,7 +155,6 @@ executable vty-demo
   hs-source-dirs:      demos
 
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
   ghc-options:         -threaded
 
   build-depends:       vty,
@@ -170,7 +166,6 @@ executable vty-demo
 
 test-suite verify-using-mock-terminal
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -203,7 +198,6 @@ test-suite verify-using-mock-terminal
 
 test-suite verify-terminal
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -236,7 +230,6 @@ test-suite verify-terminal
 
 test-suite verify-display-attributes
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -268,7 +261,6 @@ test-suite verify-display-attributes
 
 test-suite verify-empty-image-props
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -294,7 +286,6 @@ test-suite verify-empty-image-props
 
 test-suite verify-eval-terminfo-caps
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -323,7 +314,6 @@ test-suite verify-eval-terminfo-caps
 
 test-suite verify-image-ops
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -351,7 +341,6 @@ test-suite verify-image-ops
 
 test-suite verify-image-trans
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -379,7 +368,6 @@ test-suite verify-image-trans
 
 test-suite verify-inline
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -406,7 +394,6 @@ test-suite verify-inline
 
 test-suite verify-parse-terminfo-caps
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -435,7 +422,6 @@ test-suite verify-parse-terminfo-caps
 
 test-suite verify-simple-span-generation
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -467,7 +453,6 @@ test-suite verify-simple-span-generation
 
 test-suite verify-crop-span-generation
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -499,7 +484,6 @@ test-suite verify-crop-span-generation
 
 test-suite verify-layers-span-generation
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -530,7 +514,6 @@ test-suite verify-layers-span-generation
 
 test-suite verify-color-mapping
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -556,7 +539,6 @@ test-suite verify-color-mapping
 
 test-suite verify-utf8-width
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                detailed-0.9
 
@@ -582,13 +564,14 @@ test-suite verify-utf8-width
 
 test-suite verify-using-mock-input
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                exitcode-stdio-1.0
 
   hs-source-dirs:      test
 
   main-is:             VerifyUsingMockInput.hs
+
+  other-modules:       Verify.Graphics.Vty.Output
 
   build-depends:       vty,
                        Cabal >= 1.20,
@@ -616,7 +599,6 @@ test-suite verify-using-mock-input
 
 test-suite verify-config
   default-language:    Haskell2010
-  default-extensions:  ScopedTypeVariables
 
   type:                exitcode-stdio-1.0
 


### PR DESCRIPTION
I like to make it so files can be copied into other projects with minimal effort, especially for tests, because those are the ones 
I tend to copy from when learning how a library should be used. Generally, I like to be explicit in each file what extensions are used.

It seems the intention here was to pretend that `ScopedTypeVariables` is a standard Haskell feature. I disagree with that intention, but if that's the repo's intention, feel free to close this PR.