### PR TITLE
fix: Allow unevaluated bottom values in `EvResize`.

### DIFF
--- a/src/Graphics/Vty/Input/Events.hs
+++ b/src/Graphics/Vty/Input/Events.hs
@@ -51,11 +51,14 @@ data Event
     -- row. Some terminals report only that a button was released
     -- without specifying which one; in that case, Nothing is provided.
     -- Otherwise Just the button released is included in the event.
-    | EvResize Int Int
+    | EvResize ~Int ~Int
     -- ^ If read from 'eventChannel' this is the size at the time of the
     -- signal. If read from 'nextEvent' this is the size at the time the
     -- event was processed by Vty. Typically these are the same, but if
     -- somebody is resizing the terminal quickly they can be different.
+    --
+    -- Note: this is a lazy constructor to support bottom/error values
+    -- passing through the input events channel.
     | EvPaste ByteString
     -- ^ A paste event occurs when a bracketed paste input sequence is
     -- received. For terminals that support bracketed paste mode, these


### PR DESCRIPTION
This isn't the ideal fix. I'll look into making a better fix, but this
unbreaks master.

See https://github.com/jtdaugherty/vty/issues/238