### PR TITLE
Made drawing a couple of times faster

### DIFF
--- a/src/Data/Terminfo/Parse.hs
+++ b/src/Data/Terminfo/Parse.hs
@@ -23,10 +23,11 @@ import qualified Data.Vector.Unboxed as Vector
 import Numeric (showHex)
 
 import Text.Parsec
+import qualified Data.Vector.Unboxed as VU
 
 data CapExpression = CapExpression
     { capOps :: !CapOps
-    , capBytes :: !(Vector.Vector Word8)
+    , capBytes :: !(VU.Vector Word8)
     , sourceString :: !String
     , paramCount :: !Int
     , paramOps :: !ParamOps

--- a/src/Graphics/Vty/Debug.hs
+++ b/src/Graphics/Vty/Debug.hs
@@ -14,11 +14,11 @@ import qualified Data.Vector as Vector
 
 rowOpsAffectedColumns :: DisplayOps -> [Int]
 rowOpsAffectedColumns ops
-    = Vector.toList $ Vector.map spanOpsAffectedColumns ops
+    = Vector.toList $ Vector.map spanOpsAffectedColumnsTraversable ops
 
 allSpansHaveWidth :: DisplayOps -> Int -> Bool
 allSpansHaveWidth ops expected
-    = all (== expected) $ Vector.toList $ Vector.map spanOpsAffectedColumns ops
+    = all (== expected) $ Vector.toList $ Vector.map spanOpsAffectedColumnsTraversable ops
 
 spanOpsAffectedRows :: DisplayOps -> Int
 spanOpsAffectedRows ops

--- a/src/Graphics/Vty/Span.hs
+++ b/src/Graphics/Vty/Span.hs
@@ -84,7 +84,7 @@ dropOps n initOps =
                 then dropOps' (remainingColumns - w) (Vector.tail ops)
                 else pure (Just $ Skip (w - remainingColumns))
             RowEnd _ -> error "cannot split ops containing a row end"
--- let ((edgeShard, opsTaken), firstOps) =
+
 splitOpsAt :: Int -> SpanOps -> ST s (MVector s SpanOp, SpanOps)
 splitOpsAt n initOps = do
         let l = V.length initOps

--- a/src/Graphics/Vty/Span.hs
+++ b/src/Graphics/Vty/Span.hs
@@ -159,11 +159,11 @@ affectedRegion ops = (displayOpsColumns ops, displayOpsRows ops)
 
 -- | The number of columns a SpanOps affects.
 spanOpsAffectedColumns :: SpanOps -> Int
-spanOpsAffectedColumns inOps = Vector.foldl' spanOpsAffectedColumns' 0 inOps
+spanOpsAffectedColumns = Vector.foldl' (\t op -> t + spanOpsAffectedColumns' op) 0
     where
-        spanOpsAffectedColumns' t (TextSpan _ w _ _ ) = t + w
-        spanOpsAffectedColumns' t (Skip w) = t + w
-        spanOpsAffectedColumns' t (RowEnd w) = t + w
+        spanOpsAffectedColumns' (TextSpan _ w _ _ ) = w
+        spanOpsAffectedColumns' (Skip w) = w
+        spanOpsAffectedColumns' (RowEnd w) = w
 
 -- | The width of a single SpanOp in columns.
 spanOpHasWidth :: SpanOp -> Maybe (Int, Int)


### PR DESCRIPTION
Stopped copying vectors around.

I don't have exact benchmarks, but after this PR `clipText` takes up half of the time spent on drawing, and `clipText` itself is not about three times faster.