### PR TITLE
Support building with `mtl-2.3.*`

### DIFF
--- a/examples/EventEcho.hs
+++ b/examples/EventEcho.hs
@@ -4,7 +4,9 @@ import Graphics.Vty
 
 import Control.Applicative
 import Control.Arrow
-import Control.Monad.RWS
+import Control.Monad (unless)
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.RWS (MonadReader(..), MonadState(..), RWST, execRWST, modify)
 
 import Data.Sequence (Seq, (<|) )
 import qualified Data.Sequence as Seq

--- a/tests/vty-tests.cabal
+++ b/tests/vty-tests.cabal
@@ -30,7 +30,7 @@ library
                        Verify.Data.Terminfo.Parse
   build-depends:       base >= 4.8 && < 5,
                        deepseq >= 1.1 && < 1.5,
-                       mtl >= 1.1.1.0 && < 2.3,
+                       mtl >= 1.1.1.0 && < 2.4,
                        utf8-string >= 0.3 && < 1.1,
                        vector >= 0.7,
                        QuickCheck,


### PR DESCRIPTION
`mtl-2.3.*` no longer re-exports `Control.Monad` or `Control.Monad.IO.Class` from `Control.Monad.RWS`. This breaks some code in a `vty` example, so this patch adapts to the change by using explicit imports.

This is a prerequisite to making `vty` build with GHC 9.6, which bundles `mtl-2.3.1`.