### PR TITLE
fix build

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,2 @@
 packages: .
           tests/
-          examples/


### PR DESCRIPTION
Examples directory was removed in 845117256a67892bce55878d717c0478b493ba93.
However, this broke invocation of `build.sh`.