### PR TITLE
Preliminary support for ghc-9.14

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,14 @@
 packages: .
           tests/
 
-if impl (ghc >= 9.12)
+tests: True
+
+test-show-details: direct
+
+if impl (ghc >= 9.14)
   allow-newer:
+    , directory:time
+    , primitive:base
     , splitmix:base
+    , tagged:template-haskell
+    , test-framework:time

--- a/vty.cabal
+++ b/vty.cabal
@@ -51,7 +51,8 @@ library
                        utf8-string >= 0.3 && < 1.1,
                        vector >= 0.7,
                        binary,
-                       parsec,
+                       -- Earlier versions have an identifier clash with mtl.
+                       parsec >= 3.1.18,
                        filepath,
                        directory
 


### PR DESCRIPTION
Currently using ghc-9.14.0.20250908.

**Probably not worth merging this until the first full release of `ghc-9.14`.**